### PR TITLE
Link @mfrost503 to correct GitHub profile page

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
 										</h4>
 
 										<p>A high quality Twitter API library, ported from <a href="https://code.google.com/p/python-twitter/">python-twitter</a>.</p>
-										<p>Package development lead by Frost (<a href="https://github.com/bencorlett">@mfrost503</a>)</p>
+										<p>Package development lead by Frost (<a href="https://github.com/mfrost503">@mfrost503</a>)</p>
 									</div>
 								</li>
 


### PR DESCRIPTION
Package development lead for Twitter project was linking to the wrong GitHub profile.
