### PR TITLE
Add PSR-2 to "Our Definition of Quality"

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,9 @@ title: The League of Extraordinary Packages
                     <p>Follow <a href="http://www.php-fig.org/psr/psr-4/">PSR-4</a>, we use <code>League</code> as our <a href="http://www.php-fig.org/psr/psr-0/">PSR-0</a> namespace.</p>
                 </li>
                 <li>
+                    <p>Adhere to <a href="http://www.php-fig.org/psr/psr-2/">PSR-2</a> as the coding style guide.</p>
+                </li>
+                <li>
                     <p>List on Packagist, we list with <code>league</code> as the vendor namespace.</p>
                 </li>
                 <li>


### PR DESCRIPTION
This adds PSR-2 into the "Our Definition Of Quality" list (as per https://twitter.com/philsturgeon/status/509390953724272640) so as to be explicit about the supported standards.

I've tried to group the PSR-related items together, though I've added it below PSR-4 as I feel PSR-4 is slightly more noteworthy than PSR-2. Feel free to muck with wording and placement.
