### PR TITLE
Replacing League URL link by League URI

### DIFF
--- a/_data/ar.yml
+++ b/_data/ar.yml
@@ -214,9 +214,9 @@ packages:
             author:
                 name: 'Ross Tuck'
                 username: 'rosstuck'
-        -   name: 'URL'
-            repo: 'url'
-            website: 'http://url.thephpleague.com'
+        -   name: 'URI'
+            repo: 'uri'
+            website: 'http://uri.thephpleague.com'
             complete: 'true'
             description: 'التعامل مع الروابط URI باستخدام PHP'
             author:

--- a/_data/de.yml
+++ b/_data/de.yml
@@ -254,11 +254,11 @@ packages:
             author:
                 name: 'Ross Tuck'
                 username: 'rosstuck'
-        -   name: 'URL'
-            repo: 'url'
-            website: 'http://url.thephpleague.com'
+        -   name: 'URI'
+            repo: 'uri'
+            website: 'http://uri.thephpleague.com'
             complete: 'true'
-            description: 'URL Manipulation einfach gemacht'
+            description: 'URI Manipulation einfach gemacht'
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'

--- a/_data/en.yml
+++ b/_data/en.yml
@@ -258,14 +258,6 @@ packages:
             repo: 'uri'
             website: 'http://uri.thephpleague.com'
             complete: 'true'
-            description: 'Modern API to process URI in PHP'
-            author:
-                name: 'Ignace Nyamagana Butera'
-                username: 'nyamsprod'
-        -   name: 'URL'
-            repo: 'url'
-            website: 'http://url.thephpleague.com'
-            complete: 'true'
             description: 'URI manipulation made easy'
             author:
                 name: 'Ignace Nyamagana Butera'

--- a/_data/es.yml
+++ b/_data/es.yml
@@ -214,11 +214,11 @@ packages:
             author:
                 name: 'Ross Tuck'
                 username: 'rosstuck'
-        -   name: 'URL'
-            repo: 'url'
-            website: 'http://url.thephpleague.com'
+        -   name: 'URI'
+            repo: 'uri'
+            website: 'http://uri.thephpleague.com'
             complete: 'true'
-            description: 'Manipulación de URLs hecha fácil'
+            description: 'Manipulación de URIs hecha fácil'
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'

--- a/_data/fr.yml
+++ b/_data/fr.yml
@@ -258,15 +258,7 @@ packages:
             repo: 'uri'
             website: 'http://uri.thephpleague.com'
             complete: 'true'
-            description: 'API modernes pour manipuler les URIs en PHP'
-            author:
-                name: 'Ignace Nyamagana Butera'
-                username: 'nyamsprod'
-        -   name: 'URL'
-            repo: 'url'
-            website: 'http://url.thephpleague.com'
-            complete: 'true'
-            description: 'Manipulation des URLs en PHP'
+            description: 'Manipulation des URIs en PHP'
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'

--- a/_data/hr.yml
+++ b/_data/hr.yml
@@ -254,9 +254,9 @@ packages:
             author:
                 name: 'Ross Tuck'
                 username: 'rosstuck'
-        -   name: 'URL'
-            repo: 'url'
-            website: 'http://url.thephpleague.com'
+        -   name: 'URI'
+            repo: 'uri'
+            website: 'http://uri.thephpleague.com'
             complete: 'true'
             description: 'URI manipulacija na lagan način'
             author:

--- a/_data/it.yml
+++ b/_data/it.yml
@@ -214,11 +214,11 @@ packages:
             author:
                 name: 'Ross Tuck'
                 username: 'rosstuck'
-        -   name: 'URL'
-            repo: 'url'
-            website: 'http://url.thephpleague.com'
+        -   name: 'URI'
+            repo: 'uri'
+            website: 'http://uri.thephpleague.com'
             complete: 'true'
-            description: 'Manipolazione degli URL facile'
+            description: 'Manipolazione degli URI facile'
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'

--- a/_data/pt-br.yml
+++ b/_data/pt-br.yml
@@ -206,11 +206,11 @@ packages:
             author:
                 name: 'Ross Tuck'
                 username: 'rosstuck'
-        -   name: 'URL'
-            repo: 'url'
-            website: 'http://url.thephpleague.com'
+        -   name: 'URI'
+            repo: 'uri'
+            website: 'http://uri.thephpleague.com'
             complete: 'true'
-            description: 'Manipulação de URL manipulation de forma fácil'
+            description: 'Manipulação de URI manipulation de forma fácil'
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'

--- a/_data/ro.yml
+++ b/_data/ro.yml
@@ -214,11 +214,11 @@ packages:
             author:
                 name: 'Ross Tuck'
                 username: 'rosstuck'
-        -   name: 'URL'
-            repo: 'url'
-            website: 'http://url.thephpleague.com'
+        -   name: 'URI'
+            repo: 'uri'
+            website: 'http://uri.thephpleague.com'
             complete: 'true'
-            description: 'Manipularea URL-urilor facută ușor'
+            description: 'Manipularea URI-urilor facută ușor'
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'

--- a/_data/ru.yml
+++ b/_data/ru.yml
@@ -214,11 +214,11 @@ packages:
             author:
                 name: 'Ross Tuck'
                 username: 'rosstuck'
-        -   name: 'URL'
-            repo: 'url'
-            website: 'http://url.thephpleague.com'
+        -   name: 'URI'
+            repo: 'uri'
+            website: 'http://uri.thephpleague.com'
             complete: 'true'
-            description: 'Простое манипулирование URL'
+            description: 'Простое манипулирование URI'
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'

--- a/_data/sl.yml
+++ b/_data/sl.yml
@@ -214,11 +214,11 @@ packages:
             author:
                 name: 'Ross Tuck'
                 username: 'rosstuck'
-        -   name: 'URL'
-            repo: 'url'
-            website: 'http://url.thephpleague.com'
+        -   name: 'URI'
+            repo: 'uri'
+            website: 'http://uri.thephpleague.com'
             complete: 'true'
-            description: 'Enostavna manipulacija URL-jev'
+            description: 'Enostavna manipulacija URI-jev'
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'


### PR DESCRIPTION
URI is the successor of URL. The link may be
re-introduced when the graveyard section is added