### PR TITLE
Send PHPUnit Coverage Listender to the cemetary

### DIFF
--- a/_data/ar.yml
+++ b/_data/ar.yml
@@ -166,14 +166,6 @@ packages:
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: 'التبليغ عن إحصائيات تغطية الشفرة البرمجية إلى خدمات الطرف الثالث'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Plates'
             repo: 'plates'
             website: 'http://platesphp.com'

--- a/_data/de.yml
+++ b/_data/de.yml
@@ -190,14 +190,6 @@ packages:
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: 'Berichte Code Statistiken an Third-Party Services'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Pipeline'
             repo: 'pipeline'
             website: 'http://pipeline.thephpleague.com'

--- a/_data/en.yml
+++ b/_data/en.yml
@@ -198,14 +198,6 @@ packages:
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: 'Report code coverage stats to third-party services'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Pipeline'
             repo: 'pipeline'
             website: 'http://pipeline.thephpleague.com'

--- a/_data/es.yml
+++ b/_data/es.yml
@@ -174,14 +174,6 @@ packages:
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: 'Reporta estadísticas de cobertura de código a servicios de terceros'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Shunt'
             repo: 'shunt'
             website: 'https://github.com/thephpleague/shunt'

--- a/_data/fr.yml
+++ b/_data/fr.yml
@@ -198,14 +198,6 @@ packages:
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: 'Envoie les statistiques de couverture de code à des services tiers'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Pipeline'
             repo: 'pipeline'
             website: 'http://pipeline.thephpleague.com'

--- a/_data/hr.yml
+++ b/_data/hr.yml
@@ -190,14 +190,6 @@ packages:
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: 'Izvještavanje pokrivenosti koda testovima trećim stranama'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Pipeline'
             repo: 'pipeline'
             website: 'http://pipeline.thephpleague.com'

--- a/_data/it.yml
+++ b/_data/it.yml
@@ -166,14 +166,6 @@ packages:
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: 'Segnala statistiche di copertura del codice a servizi di terze parti'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Plates'
             repo: 'plates'
             website: 'http://platesphp.com'

--- a/_data/pt-br.yml
+++ b/_data/pt-br.yml
@@ -166,14 +166,6 @@ packages:
             author:
                 name: 'Jonathan Reinink'
                 username: 'reinink'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: 'Relatório de estatísticas de cobertura de código para serviços de terceiros'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Shunt'
             repo: 'shunt'
             website: 'https://github.com/thephpleague/shunt'

--- a/_data/ro.yml
+++ b/_data/ro.yml
@@ -166,14 +166,6 @@ packages:
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: 'Raportează statistici despre acoperirea codul-ui serviciilor externe'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Plates'
             repo: 'plates'
             website: 'http://platesphp.com'

--- a/_data/ru.yml
+++ b/_data/ru.yml
@@ -166,14 +166,6 @@ packages:
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: 'Оповещение сторонних сервисов о покрытии кода тестами'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Plates'
             repo: 'plates'
             website: 'http://platesphp.com'

--- a/_data/sl.yml
+++ b/_data/sl.yml
@@ -158,14 +158,6 @@ packages:
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: 'Poročanje statistike pokritosti kode za tretje-osebne storitve'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Plates'
             repo: 'plates'
             website: 'http://platesphp.com'

--- a/_data/ua.yml
+++ b/_data/ua.yml
@@ -198,14 +198,6 @@ packages:
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: 'Надсилання статистики покриття коду тестами до сторонніх сервісів'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Pipeline'
             repo: 'pipeline'
             website: 'http://pipeline.thephpleague.com'

--- a/_data/zh-cn.yml
+++ b/_data/zh-cn.yml
@@ -198,14 +198,6 @@ packages:
             author:
                 name: 'Ignace Nyamagana Butera'
                 username: 'nyamsprod'
-        -   name: 'PHPUnit Coverage Listener'
-            repo: 'phpunit-coverage-listener'
-            website: 'https://github.com/thephpleague/phpunit-coverage-listener'
-            complete: 'true'
-            description: '以第三方服务报告代码覆盖率的统计'
-            author:
-                name: 'Taufan Aditya'
-                username: 'toopay'
         -   name: 'Pipeline'
             repo: 'pipeline'
             website: 'http://pipeline.thephpleague.com'


### PR DESCRIPTION
This hasn't been touched in a while, and I think I mentioned this to @toopay a while back. Three years should be considered a reasonable cut-off for a project. If anyone wants to bring it back from the [Cemetary](https://github.com/thephpleague/thephpleague.github.io/wiki/Cemetery) they can.