### PR TITLE
Improves wording of quality rule "changelogs"

### DIFF
--- a/_data/de.yml
+++ b/_data/de.yml
@@ -241,7 +241,7 @@ quality:
         - 'Schreibt Unit Tests. Eine 80% Abdeckung sollte euer Ziel sein.'
         - 'Verwendet überall <a href="http://www.phpdoc.org/docs/latest/references/phpdoc/index.html">DocBlock</a>.'
         - 'Benutzt <a href="http://semver.org/">Semantic Versioning</a> für die Unterteilung des Packages in Versionen.'
-        - 'Behaltet ein <a href="http://keepachangelog.com/">Änderungsprotokoll. (Changelog)</a>.'
+        - 'Haltet Änderungen in <a href="http://keepachangelog.com/de/">Changelogs</a> fest.'
         - 'Verwendet <a href="https://travis-ci.org/">Travis-CI</a> für die automatische Kontrolle eures Codes und für die Ausführung der Tests.'
         - 'Benutzt eine <a href="https://github.com/thephpleague/skeleton/blob/master/README.md">README</a> Datei.'
         - '<a href="https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production">Schließe nicht notwendige Dateien mithilfe von <code>.gitattributes</code> aus</a>.'


### PR DESCRIPTION
The German wording of "Behaltet ein Änderungsprotokoll" is a 1:1 translation of "Keep a changelog". However, this is not what we'd say in Germany. This way it means "Do not drop it", but it does not mean "keep it up to date". The verb "führen" would fit better but the whole sentence would stil be a bit weird.

My replacement means something like "Track changes in a changelog" and is a way more natural way of saying it in German. I've also replaced the word "Änderungsprotokoll", which is a translation of "Changelog". Everbody in IT knows what a changelog is, there is no need to translate it. However, I've also changed the keepachangelog.com link to the German version of the page.